### PR TITLE
Quick patch to enable $server->default_index('/index.html');

### DIFF
--- a/lib/CGI/Application/Server.pm
+++ b/lib/CGI/Application/Server.pm
@@ -9,7 +9,7 @@ use Scalar::Util qw( blessed reftype );
 use HTTP::Response;
 use HTTP::Status;
 
-our $VERSION = '0.062n';
+our $VERSION = '0.062n1';
 
 use base qw( HTTP::Server::Simple::CGI );
 use HTTP::Server::Simple::Static;
@@ -18,8 +18,8 @@ use HTTP::Server::Simple::Static;
 
 sub new {
     my $class = shift;
-    my $self  = $class->SUPER::new(@_); 
-    $self->{entry_points} = {};    
+    my $self  = $class->SUPER::new(@_);
+    $self->{entry_points} = {};
     $self->{document_root}  = '.';
     $self->{default_index}  = '/index.html';
     return $self;
@@ -41,7 +41,7 @@ sub default_index {
     my ($self, $default_index) = @_;
     if (defined $default_index) {
         my $default_url = $self->{document_root};
-        $default_url .= $default_index;
+    $default_url .= $default_index;
         (-f $default_url)
             || confess "The server default_index ($default_url) [$default_index] is not found";
         $self->{default_index} = $default_index;
@@ -56,7 +56,7 @@ sub entry_points {
             || confess "The entry points map must be a HASH reference, not $entry_points";
         $self->{entry_points} = $entry_points;
     }
-    $self->{entry_points};    
+    $self->{entry_points};
 }
 
 # check request
@@ -79,7 +79,7 @@ sub is_valid_entry_point {
 
     # Check to see if there's an entry for '/'
     if (exists $self->{entry_points}{'/'}) {
-	return ($uri, $self->{entry_points}{'/'});
+    return ($uri, $self->{entry_points}{'/'});
     }
 
     # Didn't find anything. Oh, well.
@@ -96,38 +96,40 @@ sub handle_request {
         (local $ENV{PATH_INFO} = $ENV{PATH_INFO}) =~ s/\A\Q$path//;
 
         if (-d $target && -x $target) {
-	  return $self->serve_static($cgi, $target);
-	}
-	elsif ($target->isa('CGI::Application::Dispatch')) {
-	  return $self->_serve_response($target->dispatch);
-        } elsif ($target->isa('CGI::Application')) {
-          if (!defined blessed $target) {
-	    return $self->_serve_response($target->new->run);
-          } else {
-        $target->query($cgi);
-	    return $self->_serve_response($target->run);
-          }
-	}
-	else {
+            return $self->serve_static($cgi, $target);
+        }
+        elsif ($target->isa('CGI::Application::Dispatch')) {
+          return $self->_serve_response($target->dispatch);
+            } elsif ($target->isa('CGI::Application')) {
+              if (!defined blessed $target) {
+            return $self->_serve_response($target->new->run);
+              } else {
+            $target->query($cgi);
+            return $self->_serve_response($target->run);
+              }
+        }
+        else {
           confess "Target must be a CGI::Application or CGI::Application::Dispatch subclass or the name of a directory that exists and is readable.\n";
         }
     } else {
-    	my $path = $cgi->path_info();
+        my $path = $cgi->path_info();
         if($path=~m/^\/?$/){
            my $file = shift || './t/www/index.html';
-                # We want to pull the fiel from $self->{document_root} .'/'. ($self->{default_index}=~s/^\//g)
-                # but you get the idea for now. LxR
-           if (-f "$file" && $file!~m/\.\./){
-                open (FILE, "<$file");
-                while(<FILE>){ print $_; } #
-                close(FILE);
+           my $index_file = $self->{document_root} . '/'. $self->{default_index};
+           if(-f $index_file){ $file = $index_file; }
+           if (-f "$file"){
+             open (FILE, "<$file");
+             while(<FILE>){ print $_; }
+             close(FILE);
            }else{
-                print qq |<a href="/cgi-bin/index.cgi">Welcome - We will be with you shortly.</a>|;
+             print "HTTP/1.1 200 OK\n";
+             print "Content-type: text/html; charset=iso-8859-1\n\n";
+             print qq |<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN"><href><body><a href="/cgi-bin/index.cgi">Welcome</a></body></html>|;
            }
            return 1;
         }
         return $self->serve_static($cgi, $self->document_root);
-    } 
+    }
 }
 
 sub _serve_response {
@@ -136,7 +138,7 @@ sub _serve_response {
   my $response = $self->_build_response( $stdout );
   print $response->as_string();
 
-  return 1;			# Like ...Simple::Static::serve_static does
+  return 1;         # Like ...Simple::Static::serve_static does
 }
 
 # Shamelessly stolen from HTTP::Request::AsCGI by chansen
@@ -174,7 +176,6 @@ sub _build_response {
         $response->code($code);
         $response->message($message);
     }
-    
     my $length = length $stdout;
 
     if ( $response->code == 500 && !$length ) {
@@ -215,6 +216,7 @@ CGI::Application::Server - A simple HTTP server for developing with CGI::Applica
   my $object = MyOtherCGIApp->new(PARAMS => { foo => 1, bar => 2 });
   
   $server->document_root('./htdocs');
+  $server->default_index('/index.html');
   $server->entry_points({
       '/'          => 'MyCGIApp::DefaultApp',
       '/index.cgi' => 'MyCGIApp',
@@ -263,6 +265,7 @@ This attempts to match the C<$uri> to an entry point.
 
 This is the server's document root where all static files will 
 be served from.
+
 
 =back
 


### PR DESCRIPTION
This enabled a default static file from the document_root and
resolves http://[::1]:8080/ to http://[::1]:8080/index.html (rather than the unhelpful blank page.)

(This is just an outline, I'm sure you will want to do it more cleanly than this dirty hack.)
